### PR TITLE
Add argument to fix probability of extreme events for _mix familes

### DIFF
--- a/R/families.R
+++ b/R/families.R
@@ -110,10 +110,11 @@ gengamma <- function(link = "log") {
 #' @details The families ending in `_mix()` are 2-component mixtures where each
 #'   distribution has its own mean but a shared scale parameter.
 #'   (Thorson et al. 2011). See the model-description vignette for details.
-#'   The parameter `plogis(log_p_mix)` is the probability of the extreme (larger)
+#'   The parameter `p_extreme = plogis(logit_p_extreme)` is the probability of the extreme (larger)
 #'   mean and `exp(log_ratio_mix) + 1` is the ratio of the larger extreme
 #'   mean to the "regular" mean. You can see these parameters in
-#'   `model$sd_report`.
+#'   `model$sd_report`. The parameter `p_extreme` can be fixed a priori and passed
+#'   in as a proportion for these families.
 #' @references
 #'
 #' *Families ending in `_mix()`*:
@@ -122,11 +123,13 @@ gengamma <- function(link = "log") {
 #' in single- and multi-species survey data using mixture distribution models.
 #' Can. J. Fish. Aquat. Sci. 68(9): 1681–1693. \doi{10.1139/f2011-086}.
 
+#' @param p_extreme Optional fixed probability for the extreme component. If NULL (default),
+#'   this is estimated. If specified, must be a proportion between 0 and 1.
 #' @export
 #' @rdname families
 #' @examples
 #' gamma_mix(link = "log")
-gamma_mix <- function(link = "log") {
+gamma_mix <- function(link = "log", p_extreme = NULL) {
   linktemp <- substitute(link)
   if (!is.character(linktemp))
     linktemp <- deparse(linktemp)
@@ -135,15 +138,24 @@ gamma_mix <- function(link = "log") {
     stats <- stats::make.link(linktemp)
   else if (is.character(link))
     stats <- stats::make.link(link)
-  x <- c(list(family = "gamma_mix", link = linktemp), stats)
+
+  if (!is.null(p_extreme)) {
+    if (!is.numeric(p_extreme) || p_extreme <= 0 || p_extreme >= 1) {
+      stop("p_extreme must be NULL or a proportion between 0 and 1")
+    }
+  }
+
+  x <- c(list(family = "gamma_mix", link = linktemp, p_extreme = p_extreme), stats)
   add_to_family(x)
 }
 
+#' @param p_extreme Optional fixed probability for the extreme component. If NULL (default),
+#'   this is estimated. If specified, must be a proportion between 0 and 1.
 #' @export
 #' @rdname families
 #' @examples
 #' lognormal_mix(link = "log")
-lognormal_mix <- function(link = "log") {
+lognormal_mix <- function(link = "log", p_extreme = NULL) {
   linktemp <- substitute(link)
   if (!is.character(linktemp))
     linktemp <- deparse(linktemp)
@@ -152,15 +164,23 @@ lognormal_mix <- function(link = "log") {
     stats <- stats::make.link(linktemp)
   else if (is.character(link))
     stats <- stats::make.link(link)
-  x <- c(list(family = "lognormal_mix", link = linktemp), stats)
+
+  if (!is.null(p_extreme)) {
+    if (!is.numeric(p_extreme) || p_extreme <= 0 || p_extreme >= 1) {
+      stop("p_extreme must be NULL or a proportion between 0 and 1")
+    }
+  }
+  x <- c(list(family = "lognormal_mix", link = linktemp, p_extreme = p_extreme), stats)
   add_to_family(x)
 }
 
+#' @param p_extreme Optional fixed probability for the extreme component. If NULL (default),
+#'   this is estimated. If specified, must be a proportion between 0 and 1.
 #' @export
 #' @rdname families
 #' @examples
 #' nbinom2_mix(link = "log")
-nbinom2_mix <- function(link = "log") {
+nbinom2_mix <- function(link = "log", p_extreme = NULL) {
   linktemp <- substitute(link)
   if (!is.character(linktemp))
     linktemp <- deparse(linktemp)
@@ -169,7 +189,13 @@ nbinom2_mix <- function(link = "log") {
     stats <- stats::make.link(linktemp)
   else if (is.character(link))
     stats <- stats::make.link(link)
-  x <- c(list(family = "nbinom2_mix", link = linktemp), stats)
+
+  if (!is.null(p_extreme)) {
+    if (!is.numeric(p_extreme) || p_extreme <= 0 || p_extreme >= 1) {
+      stop("p_extreme must be NULL or a proportion between 0 and 1")
+    }
+  }
+  x <- c(list(family = "nbinom2_mix", link = linktemp, p_extreme = p_extreme), stats)
   add_to_family(x)
 }
 
@@ -372,15 +398,18 @@ delta_gamma <- function(link1,
     clean_name = clean_name), class = "family")
 }
 
+#' @param p_extreme Optional fixed probability for the extreme component. If NULL (default),
+#'   this is estimated. If specified, must be a proportion between 0 and 1.
 #' @export
 #' @examples
 #' delta_gamma_mix()
 #' @rdname families
-delta_gamma_mix <- function(link1 = "logit", link2 = "log") {
+delta_gamma_mix <- function(link1 = "logit", link2 = "log", p_extreme = NULL) {
   f1 <- binomial(link = link1)
   f2 <- gamma_mix(link = link2)
   structure(list(f1, f2, delta = TRUE, link = c("logit", "log"),
        family = c("binomial", "gamma_mix"),
+       p_extreme = p_extreme,
        clean_name = "delta_gamma_mix(link1 = 'logit', link2 = 'log')"), class = "family")
 }
 
@@ -436,11 +465,13 @@ delta_lognormal <- function(link1,
     clean_name = clean_name), class = "family")
 }
 
+#' @param p_extreme Optional fixed probability for the extreme component. If NULL (default),
+#'   this is estimated. If specified, must be a proportion between 0 and 1.
 #' @export
 #' @examples
 #' delta_lognormal_mix()
 #' @rdname families
-delta_lognormal_mix <- function(link1, link2 = "log", type = c("standard", "poisson-link")) {
+delta_lognormal_mix <- function(link1, link2 = "log", type = c("standard", "poisson-link"), p_extreme = NULL) {
   type <- match.arg(type)
   if (missing(link1)) link1 <- if (type == "standard") "logit" else "log"
   l1 <- substitute(link1)
@@ -458,6 +489,7 @@ delta_lognormal_mix <- function(link1, link2 = "log", type = c("standard", "pois
   }
   structure(list(f1, f2, delta = TRUE, link = c(l1, l2),
        family = c("binomial", "lognormal_mix"), type = .type,
+       p_extreme = p_extreme,
        clean_name = clean_name), class = "family")
 }
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -1460,12 +1460,12 @@ sdmTMB <- function(
 
   # Handle mixture models
   if (family$family[[1]] %in% c("gamma_mix", "lognormal_mix", "nbinom2_mix")) {
-    fixed_extreme_p <- family$extreme_p
+    fixed_p_extreme <- family$p_extreme
 
-    if (!is.null(fixed_extreme_p)) {
+    if (!is.null(fixed_p_extreme)) {
       # Fix logit_p_extreme at the user-specified value
       tmb_map$logit_p_extreme <- factor(NA)
-      tmb_params$logit_p_extreme <- log(fixed_extreme_p/(1-fixed_extreme_p))
+      tmb_params$logit_p_extreme <- log(fixed_p_extreme/(1-fixed_p_extreme))
       tmb_map$log_ratio_mix <- NULL
     } else {
       tmb_map$log_ratio_mix <- NULL
@@ -1475,13 +1475,13 @@ sdmTMB <- function(
   # delta mixture models
   if (delta) {
     if (family$family[[2]] %in% c("gamma_mix", "lognormal_mix", "nbinom2_mix")) {
-      fixed_extreme_p <- family[[2]]$extreme_p
-      if (is.null(fixed_extreme_p)) fixed_extreme_p <- family$extreme_p
+      fixed_p_extreme <- family[[2]]$p_extreme
+      if (is.null(fixed_p_extreme)) fixed_p_extreme <- family$p_extreme
 
-      if (!is.null(fixed_extreme_p)) {
+      if (!is.null(fixed_p_extreme)) {
         # Fix logit_p_extreme at the user-specified value
         tmb_map$logit_p_extreme <- factor(NA)
-        tmb_params$logit_p_extreme <- log(fixed_extreme_p/(1-fixed_extreme_p))
+        tmb_params$logit_p_extreme <- log(fixed_p_extreme/(1-fixed_p_extreme))
         tmb_map$log_ratio_mix <- NULL
       } else {
         tmb_map$log_ratio_mix <- NULL

--- a/R/fit.R
+++ b/R/fit.R
@@ -1240,7 +1240,7 @@ sdmTMB <- function(
     # ln_kappa   = rep(log(sqrt(8) / median(stats::dist(spde$mesh$loc))), 2),
     thetaf = 0,
     gengamma_Q = 0.5, # Not defined at exactly 0
-    logit_p_mix = 0,
+    logit_p_extreme = 0,
     log_ratio_mix = -1, # ratio is 1 + exp(log_ratio_mix) so 0 would start fairly high
     ln_phi = rep(0, n_m),
     ln_tau_V = matrix(0, ncol(X_rw_ik), n_m),
@@ -1458,14 +1458,35 @@ sdmTMB <- function(
     tmb_map$ln_H_input <- factor(c(1, 2, 1, 2)) # share anisotropy as in VAST
   }
 
+  # Handle mixture models
   if (family$family[[1]] %in% c("gamma_mix", "lognormal_mix", "nbinom2_mix")) {
-    tmb_map$log_ratio_mix <- NULL # performs better starting this in 2nd phase
-    tmb_map$logit_p_mix <- NULL # performs better starting this in 2nd phase
+    fixed_extreme_p <- family$extreme_p
+
+    if (!is.null(fixed_extreme_p)) {
+      # Fix logit_p_extreme at the user-specified value
+      tmb_map$logit_p_extreme <- factor(NA)
+      tmb_params$logit_p_extreme <- log(fixed_extreme_p/(1-fixed_extreme_p))
+      tmb_map$log_ratio_mix <- NULL
+    } else {
+      tmb_map$log_ratio_mix <- NULL
+      tmb_map$logit_p_extreme <- NULL
+    }
   }
+  # delta mixture models
   if (delta) {
     if (family$family[[2]] %in% c("gamma_mix", "lognormal_mix", "nbinom2_mix")) {
-      tmb_map$log_ratio_mix <- NULL
-      tmb_map$logit_p_mix <- NULL
+      fixed_extreme_p <- family[[2]]$extreme_p
+      if (is.null(fixed_extreme_p)) fixed_extreme_p <- family$extreme_p
+
+      if (!is.null(fixed_extreme_p)) {
+        # Fix logit_p_extreme at the user-specified value
+        tmb_map$logit_p_extreme <- factor(NA)
+        tmb_params$logit_p_extreme <- log(fixed_extreme_p/(1-fixed_extreme_p))
+        tmb_map$log_ratio_mix <- NULL
+      } else {
+        tmb_map$log_ratio_mix <- NULL
+        tmb_map$logit_p_extreme <- NULL
+      }
     }
   }
 

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -96,26 +96,26 @@ qres_gamma <- function(object, y, mu, ...) {
 qres_gamma_mix <- function(object, y, mu, ...) {
   cli_abort("Randomized quantile residuals for this family are not implemented yet")
   # theta <- get_pars(object)
-  # p_mix <- plogis(theta[["logit_p_mix"]])
+  # p_extreme <- plogis(theta[["logit_p_extreme"]])
   # phi <- exp(theta[["ln_phi"]])
   # if (is_delta(object)) phi <- phi[2]
   # ratio <- exp(theta[["log_ratio_mix"]])
   # s1 <- phi
   # s2 <- mu / s1
   # s3 <- (ratio * mu) / s1
-  # u <- stats::pgamma(q = y, shape = s1, scale = (1-p_mix)*s2 + p_mix*s3) # this looks wrong
+  # u <- stats::pgamma(q = y, shape = s1, scale = (1-p_extreme)*s2 + p_extreme*s3) # this looks wrong
   # stats::qnorm(u)
 }
 
 qres_nbinom2_mix <- function(object, y, mu, ...) {
   cli_abort("Randomized quantile residuals for this family are not implemented yet")
   theta <- get_pars(object)
-  p_mix <- plogis(theta[["logit_p_mix"]])
+  p_extreme <- plogis(theta[["logit_p_extreme"]])
   phi <- exp(theta[["ln_phi"]])
   if (is_delta(object)) phi <- phi[2]
   ratio <- exp(theta[["log_ratio_mix"]])
-  a <- stats::pnbinom(y - 1, size = phi, mu = (1-p_mix)*mu + p_mix*ratio*mu)
-  b <- stats::pnbinom(y, size = phi, mu = (1-p_mix)*mu + p_mix*ratio*mu)
+  a <- stats::pnbinom(y - 1, size = phi, mu = (1-p_extreme)*mu + p_extreme*ratio*mu)
+  b <- stats::pnbinom(y, size = phi, mu = (1-p_extreme)*mu + p_extreme*ratio*mu)
   u <- stats::runif(n = length(y), min = a, max = b)
   stats::qnorm(u)
 }
@@ -123,11 +123,11 @@ qres_nbinom2_mix <- function(object, y, mu, ...) {
 qres_lognormal_mix <- function(object, y, mu, ...) {
   cli_abort("Randomized quantile residuals for this family are not implemented yet")
   theta <- get_pars(object)
-  p_mix <- plogis(theta[["logit_p_mix"]])
+  p_extreme <- plogis(theta[["logit_p_extreme"]])
   dispersion <- exp(theta[["ln_phi"]])
   if (is_delta(object)) dispersion <- dispersion[2]
   ratio <- exp(theta[["log_ratio_mix"]])
-  u <- stats::plnorm(q = y, meanlog = log((1-p_mix)*mu + p_mix*ratio*mu) - (dispersion^2) / 2, sdlog = dispersion)
+  u <- stats::plnorm(q = y, meanlog = log((1-p_extreme)*mu + p_extreme*ratio*mu) - (dispersion^2) / 2, sdlog = dispersion)
   stats::qnorm(u)
 }
 

--- a/man/families.Rd
+++ b/man/families.Rd
@@ -34,11 +34,11 @@ lognormal(link = "log")
 
 gengamma(link = "log")
 
-gamma_mix(link = "log")
+gamma_mix(link = "log", p_extreme = NULL)
 
-lognormal_mix(link = "log")
+lognormal_mix(link = "log", p_extreme = NULL)
 
-nbinom2_mix(link = "log")
+nbinom2_mix(link = "log", p_extreme = NULL)
 
 nbinom2(link = "log")
 
@@ -56,13 +56,18 @@ censored_poisson(link = "log")
 
 delta_gamma(link1, link2 = "log", type = c("standard", "poisson-link"))
 
-delta_gamma_mix(link1 = "logit", link2 = "log")
+delta_gamma_mix(link1 = "logit", link2 = "log", p_extreme = NULL)
 
 delta_gengamma(link1, link2 = "log", type = c("standard", "poisson-link"))
 
 delta_lognormal(link1, link2 = "log", type = c("standard", "poisson-link"))
 
-delta_lognormal_mix(link1, link2 = "log", type = c("standard", "poisson-link"))
+delta_lognormal_mix(
+  link1,
+  link2 = "log",
+  type = c("standard", "poisson-link"),
+  p_extreme = NULL
+)
 
 delta_truncated_nbinom2(link1 = "logit", link2 = "log")
 
@@ -78,6 +83,9 @@ delta_beta(link1 = "logit", link2 = "logit")
 }
 \arguments{
 \item{link}{Link.}
+
+\item{p_extreme}{Optional fixed probability for the extreme component. If NULL (default),
+this is estimated. If specified, must be a proportion between 0 and 1.}
 
 \item{df}{Student-t degrees of freedom fixed value parameter.}
 
@@ -111,10 +119,11 @@ should be the gamma.
 The families ending in \verb{_mix()} are 2-component mixtures where each
 distribution has its own mean but a shared scale parameter.
 (Thorson et al. 2011). See the model-description vignette for details.
-The parameter \code{plogis(log_p_mix)} is the probability of the extreme (larger)
+The parameter \code{p_extreme = plogis(logit_p_extreme)} is the probability of the extreme (larger)
 mean and \code{exp(log_ratio_mix) + 1} is the ratio of the larger extreme
 mean to the "regular" mean. You can see these parameters in
-\code{model$sd_report}.
+\code{model$sd_report}. The parameter \code{p_extreme} can be fixed a priori and passed
+in as a proportion for these families.
 
 The \code{nbinom2} negative binomial parameterization is the NB2 where the
 variance grows quadratically with the mean (Hilbe 2011).

--- a/src/sdmTMB.cpp
+++ b/src/sdmTMB.cpp
@@ -282,7 +282,7 @@ Type objective_function<Type>::operator()()
 
   PARAMETER(thetaf);           // tweedie only
   PARAMETER(gengamma_Q);           // gengamma only
-  PARAMETER(logit_p_mix);           // ECE / positive mixture only
+  PARAMETER(logit_p_extreme);           // ECE / positive mixture only
   PARAMETER(log_ratio_mix);           // ECE / positive mixture only
 
   PARAMETER_VECTOR(ln_phi);           // sigma / dispersion / etc.
@@ -473,8 +473,8 @@ Type objective_function<Type>::operator()()
         Q_temp = Q_s2;
       }
       if (!omit_spatial_intercept) {
-        Type spatial_scale = barrier ? 
-          sdmTMB::barrier_scaling_factor(ln_tau_O(m), ln_kappa(0,m)) : 
+        Type spatial_scale = barrier ?
+          sdmTMB::barrier_scaling_factor(ln_tau_O(m), ln_kappa(0,m)) :
           1. / exp(ln_tau_O(m));
         PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), spatial_scale)(omega_s.col(m));
         if (sim_re(0)) {
@@ -491,8 +491,8 @@ Type objective_function<Type>::operator()()
       }
       if (spatial_covariate) {
         for (int z = 0; z < n_z; z++) {
-          Type spatial_cov_scale = barrier ? 
-            sdmTMB::barrier_scaling_factor(ln_tau_Z(z,m), ln_kappa(0,m)) : 
+          Type spatial_cov_scale = barrier ?
+            sdmTMB::barrier_scaling_factor(ln_tau_Z(z,m), ln_kappa(0,m)) :
             1. / exp(ln_tau_Z(z,m));
           PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), spatial_cov_scale)(zeta_s.col(m).col(z));
           if (sim_re(3)) {
@@ -523,8 +523,8 @@ Type objective_function<Type>::operator()()
     if (!spatial_only(m)) {
       if (!ar1_fields(m) && !rw_fields(m)) {
         for (int t = 0; t < n_t; t++) {
-          Type spatiotemporal_scale = barrier ? 
-            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) : 
+          Type spatiotemporal_scale = barrier ?
+            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) :
             1. / exp(ln_tau_E_vec(t,m));
           PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), spatiotemporal_scale)(epsilon_st.col(m).col(t));
         }
@@ -545,13 +545,13 @@ Type objective_function<Type>::operator()()
         if (ar1_fields(m)) { // not using separable(ar1()) so we can simulate by time step
           // PARALLEL_REGION jnll += SCALE(SEPARABLE(AR1(rho(m)), GMRF(Q_temp, s)), 1./exp(ln_tau_E(m)))(epsilon_st.col(m));
           // Split out by year so we can turn on/off simulation by year and model covariates of ln_tau_E:
-          Type ar1_scale_0 = barrier ? 
-            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(0,m), ln_kappa(1,m)) : 
+          Type ar1_scale_0 = barrier ?
+            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(0,m), ln_kappa(1,m)) :
             1. / exp(ln_tau_E_vec(0,m));
           PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), ar1_scale_0)(epsilon_st.col(m).col(0));
           for (int t = 1; t < n_t; t++) {
-            Type ar1_scale_t = barrier ? 
-              sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) : 
+            Type ar1_scale_t = barrier ?
+              sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) :
               1. / exp(ln_tau_E_vec(t,m));
             PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), ar1_scale_t)((epsilon_st.col(m).col(t) -
               rho(m) * epsilon_st.col(m).col(t - 1))/sqrt(1. - rho(m) * rho(m)));
@@ -577,7 +577,7 @@ Type objective_function<Type>::operator()()
                     epsilon_st.col(m).col(0) = epsilon_st_tmp;
                   } else {
                     // scaled (innovation) SD for subsequent steps to achieve desired marginal SD
-                    epsilon_st.col(m).col(t) = rho(m) * epsilon_st.col(m).col(t-1) + epsilon_st_tmp * ar1_scaler; 
+                    epsilon_st.col(m).col(t) = rho(m) * epsilon_st.col(m).col(t-1) + epsilon_st_tmp * ar1_scaler;
                   }
                 }
               }
@@ -585,13 +585,13 @@ Type objective_function<Type>::operator()()
           }
           ADREPORT(rho);
         } else if (rw_fields(m)) {
-          Type rw_scale_0 = barrier ? 
-            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(0,m), ln_kappa(1,m)) : 
+          Type rw_scale_0 = barrier ?
+            sdmTMB::barrier_scaling_factor(ln_tau_E_vec(0,m), ln_kappa(1,m)) :
             1. / exp(ln_tau_E_vec(0,m));
           PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), rw_scale_0)(epsilon_st.col(m).col(0));
           for (int t = 1; t < n_t; t++) {
-            Type rw_scale_t = barrier ? 
-              sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) : 
+            Type rw_scale_t = barrier ?
+              sdmTMB::barrier_scaling_factor(ln_tau_E_vec(t,m), ln_kappa(1,m)) :
               1. / exp(ln_tau_E_vec(t,m));
             PARALLEL_REGION jnll += SCALE(GMRF(Q_temp, s), rw_scale_t)(epsilon_st.col(m).col(t) - epsilon_st.col(m).col(t - 1));
           }
@@ -717,14 +717,14 @@ Type objective_function<Type>::operator()()
               if (sim_re(4) && simulate_t(t)) {
                 // https://kaskr.github.io/adcomp/classdensity_1_1AR1__t.html
                 SIMULATE{
-                  b_rw_t(t, k, m) = rho_time(k, m) * rnorm(Type(0), sigma_V(k,m)) + 
+                  b_rw_t(t, k, m) = rho_time(k, m) * rnorm(Type(0), sigma_V(k,m)) +
                     ar1_sigma * rnorm(Type(0), sigma_V(k,m));
                 }
               }
             } else {
               if (sim_re(4) && simulate_t(t)) {
                 SIMULATE{
-                  b_rw_t(t, k, m) = rho_time(k, m) * b_rw_t(t-1, k, m) + 
+                  b_rw_t(t, k, m) = rho_time(k, m) * b_rw_t(t-1, k, m) +
                     ar1_sigma * rnorm(Type(0), sigma_V(k,m));
                 }
               }
@@ -891,7 +891,7 @@ Type objective_function<Type>::operator()()
   // close to zero: use for count data (cf binomial()$initialize)
 #define zt_lik_nearzero(x,loglik_exp) ((x < Type(0.001)) ? -INFINITY : loglik_exp)
 
-  Type s1, s2, s3, lognzprob, tmp_ll, ll_1, ll_2, p_mix, mix_ratio, tweedie_p, s2_large;
+  Type s1, s2, s3, lognzprob, tmp_ll, ll_1, ll_2, p_extreme, mix_ratio, tweedie_p, s2_large;
 
   // calcs for mix distr. first:
   int pos_model;
@@ -905,14 +905,14 @@ Type objective_function<Type>::operator()()
   case gamma_mix_family:
   case lognormal_mix_family:
   case nbinom2_mix_family: {
-    p_mix = invlogit(logit_p_mix); // probability of larger event
+    p_extreme = invlogit(logit_p_extreme); // probability of larger event
     mix_ratio = exp(log_ratio_mix) + Type(1.); // ratio of large:small values, constrained > 1.0
     for (int i = 0; i < n_i; i++) {
       mu_i_large(i) = exp(log(mu_i(i, pos_model)) + log(mix_ratio));  // mean of large component = mean of smaller * ratio
     }
-    ADREPORT(logit_p_mix);
+    ADREPORT(logit_p_extreme);
     ADREPORT(log_ratio_mix);
-    REPORT(p_mix);
+    REPORT(p_extreme);
     REPORT(mix_ratio);
     break;
   }
@@ -1075,12 +1075,12 @@ Type objective_function<Type>::operator()()
           case gamma_mix_family: {
             s1 = exp(ln_phi(m));        // shape
             s2 = mu_i(i,m) / s1;        // scale
-            ll_1 = log(Type(1. - p_mix)) + dgamma(y_i(i,m), s1, s2, true);
+            ll_1 = log(Type(1. - p_extreme)) + dgamma(y_i(i,m), s1, s2, true);
             s2_large = mu_i_large(i) / s1;    // scale
-            ll_2 = log(p_mix) + dgamma(y_i(i,m), s1, s2_large, true);
+            ll_2 = log(p_extreme) + dgamma(y_i(i,m), s1, s2_large, true);
             if (notNA) tmp_ll = sdmTMB::log_sum_exp(ll_1, ll_2);
             if (sim_obs) SIMULATE{
-              if(rbinom(Type(1),p_mix) == 0) {
+              if(rbinom(Type(1),p_extreme) == 0) {
                 y_i(i,m) = rgamma(s1, s2);
               } else {
                 y_i(i,m) = rgamma(s1, s2_large);
@@ -1089,11 +1089,11 @@ Type objective_function<Type>::operator()()
             break;
           }
         case lognormal_mix_family: {
-          ll_1 = log(Type(1. - p_mix)) + sdmTMB::dlnorm(y_i(i,m), log(mu_i(i,m)) - pow(phi(m), Type(2)) / Type(2), phi(m), true);
-          ll_2 = log(p_mix) + sdmTMB::dlnorm(y_i(i,m), log(mu_i_large(i)) - pow(phi(m), Type(2)) / Type(2), phi(m), true);
+          ll_1 = log(Type(1. - p_extreme)) + sdmTMB::dlnorm(y_i(i,m), log(mu_i(i,m)) - pow(phi(m), Type(2)) / Type(2), phi(m), true);
+          ll_2 = log(p_extreme) + sdmTMB::dlnorm(y_i(i,m), log(mu_i_large(i)) - pow(phi(m), Type(2)) / Type(2), phi(m), true);
           if (notNA) tmp_ll = sdmTMB::log_sum_exp(ll_1, ll_2);
           if (sim_obs) SIMULATE{
-            if (rbinom(Type(1), p_mix) == 0) {
+            if (rbinom(Type(1), p_extreme) == 0) {
               y_i(i,m) = exp(rnorm(log(mu_i(i,m)) - pow(phi(m), Type(2)) / Type(2), phi(m)));;
             } else {
               y_i(i,m) = exp(rnorm(log(mu_i_large(i)) - pow(phi(m), Type(2)) / Type(2), phi(m)));;
@@ -1106,15 +1106,15 @@ Type objective_function<Type>::operator()()
           s2 = Type(2.) * s1 - ln_phi(m); // log(var - mu)
           Type s1_large = log(mu_i_large(i));
           Type s2_large = Type(2.) * s1_large - ln_phi(m);
-          ll_1 = log(Type(1. - p_mix)) + dnbinom_robust(y_i(i,m), s1, s2, true);
-          ll_2 = log(p_mix) + dnbinom_robust(y_i(i,m), s1_large, s2_large, true);
+          ll_1 = log(Type(1. - p_extreme)) + dnbinom_robust(y_i(i,m), s1, s2, true);
+          ll_2 = log(p_extreme) + dnbinom_robust(y_i(i,m), s1_large, s2_large, true);
           if (notNA) tmp_ll = sdmTMB::log_sum_exp(ll_1, ll_2);
           if (sim_obs) SIMULATE{
             s1 = mu_i(i,m);
             s2 = mu_i(i,m) * (Type(1) + mu_i(i,m) / phi(m));
             s1_large = mu_i_large(i);
             s2_large = mu_i_large(i) * (Type(1) + mu_i_large(i) / phi(m));
-            if (rbinom(Type(1), p_mix) == 0) {
+            if (rbinom(Type(1), p_extreme) == 0) {
               y_i(i,m) = rnbinom2(s1, s2);
             } else {
               y_i(i,m) = rnbinom2(s1_large, s2_large);
@@ -1385,13 +1385,13 @@ Type objective_function<Type>::operator()()
 
     // for families that implement mixture models, adjust proj_eta by
     // proportion and ratio of means
-    // (1 - p_mix) * mu_i(i,m) + p_mix * (mu(i,m) * mix_ratio);
+    // (1 - p_extreme) * mu_i(i,m) + p_extreme * (mu(i,m) * mix_ratio);
     switch (family(pos_model)) {
       case gamma_mix_family:
       case lognormal_mix_family:
       case nbinom2_mix_family:
-        proj_eta.col(pos_model) = log((1. - p_mix) * exp(proj_eta.col(pos_model)) + // regular part
-               p_mix * exp(proj_eta.col(pos_model)) * mix_ratio); //large part
+        proj_eta.col(pos_model) = log((1. - p_extreme) * exp(proj_eta.col(pos_model)) + // regular part
+               p_extreme * exp(proj_eta.col(pos_model)) * mix_ratio); //large part
         break;
       default:
         break;

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -21,7 +21,7 @@ test_that("Gamma, NB2, and lognormal mixtures fit and recover mixing proportion"
     family = gamma_mix(),
     spatial = "off"
   )
-  expect_equal(m$model$par[["logit_p_mix"]], stats::qlogis(0.1), tolerance = 0.1)
+  expect_equal(m$model$par[["logit_p_extreme"]], stats::qlogis(0.1), tolerance = 0.1)
   expect_equal(exp(m$model$par[["log_ratio_mix"]]), 3.0, tolerance = 0.01)
 
   p <- predict(m, newdata = m$data)
@@ -33,7 +33,7 @@ test_that("Gamma, NB2, and lognormal mixtures fit and recover mixing proportion"
     family = lognormal_mix(),
     spatial = "off"
   )
-  expect_equal(m$model$par[["logit_p_mix"]], stats::qlogis(0.1), tolerance = 0.1)
+  expect_equal(m$model$par[["logit_p_extreme"]], stats::qlogis(0.1), tolerance = 0.1)
   expect_equal(exp(m$model$par[["log_ratio_mix"]]), 3.0, tolerance = 0.01)
 
   # NB2
@@ -49,7 +49,7 @@ test_that("Gamma, NB2, and lognormal mixtures fit and recover mixing proportion"
     family = nbinom2_mix(),
     spatial = "off"
   )
-  expect_equal(m$model$par[["logit_p_mix"]], stats::qlogis(0.1), tolerance = 0.1)
+  expect_equal(m$model$par[["logit_p_extreme"]], stats::qlogis(0.1), tolerance = 0.1)
   expect_equal(1 + exp(m$model$par[["log_ratio_mix"]]), mix_ratio, tolerance = 0.1)
 
   p <- predict(m, newdata = m$data)
@@ -106,6 +106,67 @@ test_that("Test that delta lognormal mixture fits", {
   p <- predict(m, newdata = m$data, type = "response")
   expect_equal(mean(p$est), mean(d$y), tolerance = 0.01)
   # expect_length(residuals(m, model = 2), nrow(d))
+})
+
+test_that("Test that mixture with fixed extreme_p works", {
+  skip_on_cran()
+
+  set.seed(1)
+  y0 <- rep(0, 500)
+  y1 <- stats::rlnorm(500, 0, 0.5)
+  y2 <- stats::rlnorm(100, 1, 0.5)
+  d <- data.frame(y = c(y0, y1, y2))
+
+  m <- sdmTMB(
+    data = d,
+    formula = y ~ 1,
+    family = delta_lognormal_mix(extreme_p=0.1),
+    spatial = "off"
+  )
+  vals <- m$sd_report$value
+  expect_equal(as.numeric(vals[which(names(vals) == "logit_p_extreme")]),
+               log(0.1/(1-0.1)))
+  expect_equal(round(as.numeric(vals[which(names(vals) == "log_ratio_mix")]),3),
+               0.602)
+
+  m <- sdmTMB(
+    data = d,
+    formula = y ~ 1,
+    family = delta_gamma_mix(extreme_p=0.1),
+    spatial = "off"
+  )
+  vals <- m$sd_report$value
+  expect_equal(as.numeric(vals[which(names(vals) == "logit_p_extreme")]),
+               log(0.1/(1-0.1)))
+  expect_equal(round(as.numeric(vals[which(names(vals) == "log_ratio_mix")]),3),
+               0.675)
+
+  d <- data.frame(y = c(y1, y2))
+
+  m <- sdmTMB(
+    data = d,
+    formula = y ~ 1,
+    family = lognormal_mix(extreme_p=0.1),
+    spatial = "off"
+  )
+  vals <- m$sd_report$value
+  expect_equal(as.numeric(vals[which(names(vals) == "logit_p_extreme")]),
+               log(0.1/(1-0.1)))
+  expect_equal(round(as.numeric(vals[which(names(vals) == "log_ratio_mix")]),3),
+               0.602)
+
+  m <- sdmTMB(
+    data = d,
+    formula = y ~ 1,
+    family = gamma_mix(extreme_p=0.1),
+    spatial = "off"
+  )
+  vals <- m$sd_report$value
+  expect_equal(as.numeric(vals[which(names(vals) == "logit_p_extreme")]),
+               log(0.1/(1-0.1)))
+  expect_equal(round(as.numeric(vals[which(names(vals) == "log_ratio_mix")]),3),
+               0.675)
+
 })
 
 test_that("Test that simulation functions work with mixture models", {

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -108,7 +108,7 @@ test_that("Test that delta lognormal mixture fits", {
   # expect_length(residuals(m, model = 2), nrow(d))
 })
 
-test_that("Test that mixture with fixed extreme_p works", {
+test_that("Test that mixture with fixed p_extreme works", {
   skip_on_cran()
 
   set.seed(1)
@@ -120,7 +120,7 @@ test_that("Test that mixture with fixed extreme_p works", {
   m <- sdmTMB(
     data = d,
     formula = y ~ 1,
-    family = delta_lognormal_mix(extreme_p=0.1),
+    family = delta_lognormal_mix(p_extreme=0.1),
     spatial = "off"
   )
   vals <- m$sd_report$value
@@ -132,7 +132,7 @@ test_that("Test that mixture with fixed extreme_p works", {
   m <- sdmTMB(
     data = d,
     formula = y ~ 1,
-    family = delta_gamma_mix(extreme_p=0.1),
+    family = delta_gamma_mix(p_extreme=0.1),
     spatial = "off"
   )
   vals <- m$sd_report$value
@@ -146,7 +146,7 @@ test_that("Test that mixture with fixed extreme_p works", {
   m <- sdmTMB(
     data = d,
     formula = y ~ 1,
-    family = lognormal_mix(extreme_p=0.1),
+    family = lognormal_mix(p_extreme=0.1),
     spatial = "off"
   )
   vals <- m$sd_report$value
@@ -158,7 +158,7 @@ test_that("Test that mixture with fixed extreme_p works", {
   m <- sdmTMB(
     data = d,
     formula = y ~ 1,
-    family = gamma_mix(extreme_p=0.1),
+    family = gamma_mix(p_extreme=0.1),
     spatial = "off"
   )
   vals <- m$sd_report$value

--- a/vignettes/model-description.Rmd
+++ b/vignettes/model-description.Rmd
@@ -545,21 +545,18 @@ $$ where $\phi$ represents the Gamma shape, $\mu_{1} / \phi$ represents the scal
 
 The mean is $(1-p) \cdot \mu_{1} + p \cdot \mu_{2}$ and the variance is $(1-p) ^ 2 \cdot \mu_{1} \cdot \phi^2 + (p) ^ 2 \cdot \mu_{2} \cdot \phi^2$.
 
-Here, and for the other mixture distributions, the probability of the larger mean can be obtained from `plogis(fit$model$par[["logit_p_mix"]])` and the ratio of the larger mean to the smaller mean can be obtained from `1 + exp(fit$model$par[["log_ratio_mix"]])`.
+Here, and for the other mixture distributions, the probability of the larger mean can be obtained from `plogis(fit$model$par[["logit_p_extreme"]])` and the ratio of the larger mean to the smaller mean can be obtained from `1 + exp(fit$model$par[["log_ratio_mix"]])`.
 The standard errors are available in the TMB sdreport: `fit$sd_report`.
 
-If you wish to fix the probability of a large (i.e., extreme) mean, which can be hard to estimate, you can use the `map` list. E.g.:
+If you wish to fix the probability of a large (i.e., extreme) mean, which can be hard to estimate, you can fix this value and pass this to the family:
 
 ```r
 sdmTMB(...,
-  control = sdmTMBcontrol(
-    start = list(logit_p_mix = qlogis(0.05)), # 5% probability of 'mu2'
-    map = list(logit_p_mix = factor(NA)) # don't estimate
-  )
+  family = gamma_mix(link = "log", p_extreme = 0.01)
 )
 ```
 
-Example: `family = gamma_mix(link = "log")`. See also `family = delta_gamma_mix()` for an extension incorporating this distribution with delta models.
+See also `family = delta_gamma_mix()` for an extension incorporating this distribution with delta models.
 
 ## Lognormal mixture
 
@@ -573,7 +570,13 @@ Because of the bias correction, $\mathbb{E}[y] = (1-p) \cdot \mu_{1} + p \cdot \
 
 As with the Gamma mixture, $p$ controls the contribution of each component to the mixture (also interpreted as the probability of larger events).
 
-Example: `family = lognormal_mix(link = "log")`. See also `family = delta_lognormal_mix()` for an extension incorporating this distribution with delta models. 
+Example: `family = lognormal_mix(link = "log")`. See also `family = delta_lognormal_mix()` for an extension incorporating this distribution with delta models. Like with the gamma mixture, fixed probabilities of extreme events ($p$ in notation above) can be passed in, e.g.
+
+```r
+sdmTMB(...,
+  family = delta_lognormal_mix(p_extreme = 0.01)
+)
+```
 
 ## Negative binomial 2 mixture
 


### PR DESCRIPTION
https://github.com/pbs-assess/sdmTMB/issues/318

- added `p_extreme` as argument to all _mix families allowing this to be fixed
- included mapping off code in fit.r
- in .cpp file, changed `p_mix` to `p_extreme` throughout for clarity 