### PR TITLE
allow.new.levels to include population level predictions for unobserved levels in grouping vars

### DIFF
--- a/man/predict.sdmTMB.Rd
+++ b/man/predict.sdmTMB.Rd
@@ -11,6 +11,7 @@
   se_fit = FALSE,
   re_form = NULL,
   re_form_iid = NULL,
+  allow.new.levels = NULL,
   nsim = 0,
   sims_var = "est",
   model = c(NA, 1, 2),
@@ -50,6 +51,15 @@ Likely to be used in conjunction with \code{se_fit = TRUE}. This does not affect
 predictions. \code{~0} or \code{NA} for population-level predictions. No other
 options (e.g., some but not all random intercepts) are implemented yet.
 Only affects predictions with \code{newdata}. This \emph{does} affects \code{\link[=get_index]{get_index()}}.}
+
+\item{allow.new.levels}{Logical or \code{NULL}. Follows the same behavior as
+glmmTMB's \code{allow.new.levels} and allows predictions for previously
+unobserved levels in random effect grouping variables. If \code{NULL} (default),
+new levels are allowed when \code{re_form_iid = NA} (population-level
+predictions) and a warning is issued otherwise. If \code{TRUE}, new levels are
+explicitly allowed. If \code{FALSE}, a warning is issued if new levels are
+found. New levels are always treated as population-level predictions
+(random effects = 0). .}
 
 \item{nsim}{If \verb{> 0}, simulate from the joint precision
 matrix with \code{nsim} draws. Returns a matrix of \code{nrow(data)} by \code{nsim}

--- a/tests/testthat/test-factor-levels.R
+++ b/tests/testthat/test-factor-levels.R
@@ -65,10 +65,12 @@ test_that("Test that droplevels matches glmmTMB on (1 | factor)", {
   ))
   p1 <- predict(fit_glmmTMB, newdata = nd, re.form = NULL)
 
-  expect_error({
-    p2 <- predict(fit_sdmTMB, newdata = nd)$est
-  }, regexp = "levels")
-  # expect_equal(p1, p2, tolerance = 1e-3)
+  expect_warning(
+    p2 <- predict(fit_sdmTMB, newdata = nd),
+    "Found new levels for"
+  )
+  p2 <- suppressWarnings(predict(fit_sdmTMB, newdata = nd))
+  expect_equal(cor(p1, p2$est), 1)
 
   # drop level on predict
   nd <- d
@@ -79,10 +81,12 @@ test_that("Test that droplevels matches glmmTMB on (1 | factor)", {
   ))
 
   p1 <- predict(fit_glmmTMB, newdata = nd, re.form = NULL)
-  expect_error({
-    p2 <- predict(fit_sdmTMB, newdata = nd)$est
-  }, regexp = "levels")
-  # expect_equal(p1, p2, tolerance = 1e-3)
+  expect_warning(
+    p2 <- predict(fit_sdmTMB, newdata = nd),
+    "Found new levels for"
+  )
+  p2 <- suppressWarnings(predict(fit_sdmTMB, newdata = nd))
+  expect_equal(cor(p1, p2$est), 1)
 })
 
 test_that("re_form_iid is not specified but new levels in newdata doesn't blow up", {
@@ -99,9 +103,12 @@ test_that("re_form_iid is not specified but new levels in newdata doesn't blow u
   d <- pcod
   d$fyear <- as.factor(d$year)
   p <- predict(fit, newdata = d, re_form_iid = NA) # works
-  expect_error({
-    predict(fit, newdata = d) # blows up
-  }, regexp = "levels")
+
+  expect_warning(
+    p1 <- predict(fit, newdata = d),
+    "Found new levels for"
+  )
+  p1 <- suppressWarnings(predict(fit, newdata = d))
 
   # what about just with 1 level?
   fit_glmmTMB <- glmmTMB::glmmTMB(density ~ 1 + (1 | fyear),

--- a/tests/testthat/test-random-effects.R
+++ b/tests/testthat/test-random-effects.R
@@ -262,11 +262,6 @@ test_that("Model with random intercepts fits appropriately.", {
     sdmTMB_re$re_b_pars[,1],
     tolerance = 1e-5
   )
-#
-  # predicting with new levels throws error for now:
-  m <- sdmTMB(data = s, formula = observed ~ 1 + (1 | g), spatial = "off")
-  nd <- data.frame(g = factor(c(1, 2, 3, 800)), observed=1)
-  expect_error(predict(m, newdata = nd), regexp = "Extra")
 
   # predicting with missing factors works with the right re_form_iid
   m <- sdmTMB(data = s, formula = observed ~ 1 + (1 | g), spatial = "off")

--- a/tests/testthat/test-random-intercepts.R
+++ b/tests/testthat/test-random-intercepts.R
@@ -136,10 +136,17 @@ test_that("Model with random intercepts fits appropriately.", {
     tolerance = 1e-5
   )
 
-  # predicting with new levels throws error for now:
+  # predicting with new levels generates population level predictions:
   m <- sdmTMB(data = s, formula = observed ~ 1 + (1 | g), spatial = "off")
-  nd <- data.frame(g = factor(c(1, 2, 3, 800)))
-  expect_error(predict(m, newdata = nd), regexp = "Extra levels found")
+  nd <- data.frame(g = factor(c(800)))
+
+  expect_warning(
+    p2 <- predict(m, nd),
+    "Found new levels for"
+  )
+  p2 <- suppressWarnings(predict(m, nd))
+
+  expect_equal(p2$est, as.numeric(coef(m)))
 })
 
 test_that("Random intercepts and cross validation play nicely", {


### PR DESCRIPTION
This issue, https://github.com/pbs-assess/sdmTMB/issues/196

