### PR TITLE
Fix make_category_svc() formula to suppress implicit intercept

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -842,8 +842,9 @@ make_category_svc <- function(data,
   # Expand data
   data_expanded <- cbind(data, combined_matrix)
 
-  # Create formula
-  svc_formula <- as.formula(paste0("~ `", paste(colnames_combined, collapse = "` + `"), "`"))
+  # Create formula (0 + suppresses the implicit intercept so model.matrix()
+  # returns exactly n_spatial + n_spatiotemporal columns, matching svc_map)
+  svc_formula <- as.formula(paste0("~ 0 + `", paste(colnames_combined, collapse = "` + `"), "`"))
 
   # Create info summary
   info <- list(


### PR DESCRIPTION
The svc_formula generated by make_category_svc() lacked a leading `0 +`,
so model.matrix() added an implicit intercept column when sdmTMB() called
model.matrix(spatial_varying, data) internally.  Commit 336bff9 changed
the intercept-stripping logic in fit.R so that the intercept is no longer
removed when spatial = "off", causing n_z (ncol of z_i) to be one larger
than the length of the svc_map factor → TMB error "A map factor length
must equal parameter length".

Adding `0 +` to the formula ensures model.matrix() returns exactly
n_spatial + n_spatiotemporal columns, matching the svc_map factor that
make_category_svc() constructs.

Fixes the pkgdown build failure in vignettes/articles/age-composition.Rmd.

https://claude.ai/code/session_01A1RjemiXVrcqKiDVT5KZrN