### PR TITLE
Fixing issues with random effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # sdmTMB (development version)
 
+* The correctly transformed correlation between a random slope and intercept is 
+  now displayed by `print()` and `tidy()`.
+
 * Use `tryCatch()` on Newton loops in optimization to abort those steps
   instead of producing an error.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # sdmTMB (development version)
 
+* Allow for fitting uncorrelated random slopes and intercepts with the form
+  `(1 + slope_var || group)`, making sure that results are displayed correctly.
+
 * The correctly transformed correlation between a random slope and intercept is 
   now displayed by `print()` and `tidy()`.
 

--- a/R/parsing.R
+++ b/R/parsing.R
@@ -6,6 +6,15 @@ barnames <- function(bars) {
   vapply(bars, function(x) safe_deparse(x[[3]]), "")
 }
 
+# termnames is an internal function to return the names of the intercept and/or
+# slope terms before a bar in a formula, e.g. (1|group), (1+slope|group),
+# or (0+slope|group)
+# @param bars The character string representing the random effects, e.g. `1 |
+#   group`
+termnames <- function(bars) {
+  vapply(bars, function(x) safe_deparse(x[[2]]), "")
+}
+
 # make_indices is an internal function to build lower triangular matrices for
 # correlated random effects
 # @param vec Vector of indices to generate row and col positions for
@@ -33,13 +42,16 @@ make_indices <- function(vec) {
 parse_formula <- function(f, data) {
   b <- reformulas::findbars(f) # find expressions separated by |, NULL if no RE
   bn <- barnames(b) # names of groups
+  tn <- termnames(b) # names of terms
   fe_form <- reformulas::nobars(f) # fixed effect formula, no bars
   re_cov_terms <- NULL
 
   re_cov_terms <- list(
-    Zt = NULL, theta = NULL, Lind = NULL, Gp = NULL,
-    lower = NULL, Lambdat = NULL, flist = NULL,
-    cnms = NULL, Ztlist = NULL, nl = NULL
+    Zt = NULL, theta = NULL,
+    Lind = NULL, Gp = NULL,
+    lower = NULL, Lambdat = NULL,
+    flist = NULL, cnms = NULL,
+    Ztlist = NULL, nl = NULL
   )
   re_cov_terms$re_df <- data.frame(
     group_indices = integer(0),
@@ -73,8 +85,10 @@ parse_formula <- function(f, data) {
     re_cov_terms <- reformulas::mkReTrms(b, mf,
       drop.unused.levels = TRUE,
       reorder.terms = FALSE, # default is true, reorder based on dec levels
-      reorder.vars = FALSE
-    ) # keep not alphabetical
+      reorder.vars = FALSE, # keep not alphabetical
+      calc.lambdat = FALSE # Lambdat and Lind needed for lme4, but not glmmTMB (according to Bolker),
+      # so probably not needed for sdmTMB
+    )
     # re_cov_terms$theta gives the total number of params across v-cov matrices
     # see lme4 vignettes for construction details. These are indexes with
     # Lind which maps elements of theta to the VCov matrices.
@@ -103,9 +117,9 @@ parse_formula <- function(f, data) {
     # index the level / group of the elements of Zt
     for (i in seq_len(length(re_cov_terms$Ztlist))) {
       levels <- levels(data[, bn[[i]]])
-      # Add the group and ":" to the name for each -- otherwise the level names might be the
-      # same, especially if the levels ids are integers for 2+ groups
-      level_ids <- paste0(bn[[i]], ":", rownames(re_cov_terms$Ztlist[[i]]))
+      # Add the term(s) and group to the name for each (separated by ":") -- otherwise
+      # the level names might be the same, especially if the levels ids are integers for 2+ groups.
+      level_ids <- paste0(tn[[i]], ":", bn[[i]], ":", rownames(re_cov_terms$Ztlist[[i]]))
       if (i == 1) {
         df <- data.frame(
           index = seq_len(length(level_ids)),

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -780,7 +780,7 @@ get_re_tidy_list <- function(x, crit, model = 1, delta = FALSE) {
     re_b_df <- re_b_df[, c("group_name", "term", "level_ids", "estimate", "std.error", "conf.low", "conf.high")]
   }
   # remove ":" in the level_ids
-  re_b_df$level_ids <- sapply(strsplit(re_b_df$level_ids, ":"), function(x) x[2])
+  re_b_df$level_ids <- sapply(strsplit(re_b_df$level_ids, ":"), function(x) x[3])
   out_ranef <- re_b_df
   row.names(out_ranef) <- NULL
 
@@ -800,6 +800,19 @@ get_re_tidy_list <- function(x, crit, model = 1, delta = FALSE) {
     indx <- which(group_key$model == re_cov_df$model[i] & group_key$group_id == (re_cov_df$group_indices[i] + 1))
     re_cov_df$group[i] <- group_key$group_name[indx]
   }
+
+  # Uncorrelated random intercepts and slopes for the same group, e.g. (1|group)+(0+slope|group),
+  # are fit internally as if they were separate groups, but their SDs should be displayed
+  # in a 2-by-2 matrix with NAs on the off-diagonals.
+  true_group_dfs <- list()
+  for (i in seq_len(length(unique(re_cov_df$group)))) {
+    group <- unique(re_cov_df$group)[i]
+    true_group_dfs[[i]] <- re_cov_df[re_cov_df$group == group,]
+    correction <- true_group_dfs[[i]]$group_indices - true_group_dfs[[i]]$group_indices[1]
+    true_group_dfs[[i]]$rows <- true_group_dfs[[i]]$rows + correction
+    true_group_dfs[[i]]$cols <- true_group_dfs[[i]]$cols + correction
+  }
+  re_cov_df <- do.call(rbind, true_group_dfs)
 
   re_indx <- grep("re_cov_pars", names(x$sd_report$value), fixed = TRUE)
   non_nas <- which(x$sd_report$value[re_indx] != 0) # remove parameter that gets mapped off

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -716,8 +716,8 @@ get_anisotropic_ranges <- function(x, m = 1L) {
 # Extract and format random effect estimates from sdmTMB model output
 #
 # This function extracts random effect estimates, including individual random intercepts
-# and slopes, as well as covariance matrices, from an `sdmTMB` model output. It formats
-# them into a structured list for further analysis.
+# and slopes, as well as standard deviation and correlation parameters, from an
+# `sdmTMB` model output. It formats them into a structured list for further analysis.
 #
 # @param x An `sdmTMB` model object containing estimated random effects.
 # @param crit The critical value for confidence interval computation,
@@ -791,7 +791,7 @@ get_re_tidy_list <- function(x, crit, model = 1, delta = FALSE) {
     df
   })
   re_cov_df <- do.call(rbind, re_cov_dfs)
-  re_cov_df$rows <- re_cov_df$rows + 1 # increement rows/cols from 1, not 0
+  re_cov_df$rows <- re_cov_df$rows + 1 # increment rows/cols from 1, not 0
   re_cov_df$cols <- re_cov_df$cols + 1
   row.names(re_cov_df) <- NULL
 
@@ -809,11 +809,18 @@ get_re_tidy_list <- function(x, crit, model = 1, delta = FALSE) {
   re_cov_df$conf.high <- re_cov_df$estimate + crit * re_cov_df$std.error
   # the SD parameters are returned in log space -- calculate CIs in log space then transform
   sds <- which(re_cov_df$is_sd == 1) # index which elements are SDs
+  corr_pars <- which(re_cov_df$is_sd == 0) # assume elements which are not SDs can be transformed
+  # to obtain correlations
   # Calculate CIs in log space first
   re_cov_df$conf.low[sds] <- exp(re_cov_df$estimate[sds] - crit * re_cov_df$std.error[sds])
   re_cov_df$conf.high[sds] <- exp(re_cov_df$estimate[sds] + crit * re_cov_df$std.error[sds])
   # Transform estimates to natural space
   re_cov_df$estimate[sds] <- exp(re_cov_df$estimate[sds])
+
+  # Transform the estimates and CIs for the correlation parameters
+  re_cov_df$estimate[corr_pars] <- re_cov_df$estimate[corr_pars]/sqrt(1+(re_cov_df$estimate[corr_pars])^2)
+  re_cov_df$conf.low[corr_pars] <- re_cov_df$conf.low[corr_pars]/sqrt(1+(re_cov_df$conf.low[corr_pars])^2)
+  re_cov_df$conf.high[corr_pars] <- re_cov_df$conf.high[corr_pars]/sqrt(1+(re_cov_df$conf.high[corr_pars])^2)
 
   re_cov_df <- re_cov_df[, c("rows", "cols", "model", "group", "estimate", "std.error", "conf.low", "conf.high")]
   cov_matrices_lo = create_cov_matrices(re_cov_df, col_name = "conf.low", model = model)

--- a/tests/testthat/test-random-effects.R
+++ b/tests/testthat/test-random-effects.R
@@ -118,7 +118,7 @@ test_that("Model with random intercepts fits appropriately.", {
   expect_equal(as.numeric(attr(summary(lmer_fit)$varcor[[1]], "stddev")),
                as.numeric(exp(REs[c(1,3)])), tolerance = 1.0e-4)
   expect_equal(as.numeric(attr(summary(lmer_fit)$varcor[[1]], "correlation")[1,2]),
-               as.numeric(REs[2]), tolerance = 1.0e-2)
+               as.numeric(REs[2])/sqrt(1+as.numeric(REs[2])^2), tolerance = 1.0e-4)
 
   # Check that ranef() returns the same thing
   expect_equal(mean(diag(cor(ranef(sdmTMB_fit)[[1]]$Subject, ranef(lmer_fit)$Subject))), 1)

--- a/tests/testthat/test-random-effects.R
+++ b/tests/testthat/test-random-effects.R
@@ -175,13 +175,17 @@ test_that("Model with random intercepts fits appropriately.", {
 
 
   sdmTMB_fit <- sdmTMB(Reaction ~ Days + (1 + Days | Subject) + (1 | age), sleepstudy, spatial="off")
-
+  glmmtmb_fit <- glmmTMB::glmmTMB(Reaction ~ Days + (Days | Subject) + (1|age), sleepstudy, REML = FALSE)
 
   expect_equal(glmmTMB::fixef(glmmTMB_fit)$cond[1], coef(sdmTMB_fit)[1], tolerance = 1e-2)
   expect_equal(glmmTMB::fixef(glmmTMB_fit)$cond[2], coef(sdmTMB_fit)[2], tolerance = 1e-2)
   REs <- sdmTMB_fit$sd_report$value[grep("cov_pars", names(sdmTMB_fit$sd_report$value))]
   expect_equal(as.numeric(attr(summary(glmmTMB_fit)$varcor$cond$Subject, 'stddev')),
                as.numeric(exp(REs[c(1,3)])), tolerance = 1.0e-3)
+
+  # Check uncorrelated random intercept and slope
+  sdmTMB_fit <- sdmTMB(Reaction ~ Days + (1 + Days || Subject) + (1 | age), sleepstudy, spatial="off")
+  expect_equal(tidy(sdmTMB_fit, "ran_vcov")$est[[1]][2,1], NA_real_)
 
   # Add in spatial field
   set.seed(1)


### PR DESCRIPTION
I have recently been fitting models with random slopes, and encountered a few problems which I hope to have now fixed with these changes. 

I was fitting a species distribution model with a random intercept and age effect by vessel, expressed as `(1 + age | vessel)`. While the estimates for the standard deviations of each random effect looked good, I noticed that the estimated correlation between the random slope and intercept was not between -1 and 1. I looked into the code, and found that the `re_cov_pars` in the fitted model's `sdreport` comprise the log standard deviations as well as $\theta$ parameters which need to be transformed to get the correlations. I noticed that `get_re_tidy_list()` properly transforms the log SDs, but did not transform the $\theta$ parameter, so I implemented the transformation $\rho = \frac{\theta}{\sqrt{1+\theta^2}}$ which works when we only need to estimate one correlation parameter. I found [this](https://cran.r-project.org/web/packages/glmmTMB/refman/glmmTMB.html#get_cor) glmmTMB documentation page very helpful for understanding what was going on. The random effects test file did not pick up on the missing transformation because the fitted correlation for the sleepstudy data happened to be very small--and thus very close the the $\theta$ value. I increased the required precision in the test.

More complicated random effects structures like `(1 + var1 + var2 | group)`, for which we would need to estimate 3 SDs and 3 correlations, will not currently work in sdmTMB because each correlation needs to be calculated in a different way from the 3 $\theta$ parameters. (glmmTMB's `get_cor()` and `put_cor()` functions transform between the actual correlation matrix and the lower triangular matrix that TMB uses.) Models containing these types of effects may not be very common, but it might be a good idea to make an error message if somebody tries to fit one.

I then tried to fit a model with a random intercept and random slope for the same group but which are uncorrelated. The following `lme4`-style syntaxes for this are equivalent: `(1  + age || vessel)`, `(1 | vessel) + (0 + age | vessel)`, and `(1 | vessel) + (-1 + age | vessel)`. Unfortunately, these models would not fit, even though one with a random slope and no random intercept would, i.e. `(0 + age | vessel)`. I looked into how sdmTMB fits random effects, and found that the default correlation matrix is the [unstructured](https://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html) one from TMB. Thus, when we explicitly do not want to estimate a correlation between a random slope and intercept, they are treated as completely separate effects, just like two random intercepts for different groups, e.g. `(1 | group1) + (1 | group2)`. 

This method results in good estimates for the SDs of the uncorrelated random intercept and slope, but creates issues with constructing and working with the `split_formula` object due to the artificially high number of groups. I have tried to fix this in the `parse_formula()` and `get_re_tidy_list()` functions. My solution is not particularly elegent, but it seems to work under the different random effects configurations I've discussed here. 

Thank you,
Joseph